### PR TITLE
Update docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Here's a quick start tutorial using only docker and docker-compose to start-up a [Prometheus](http://prometheus.io/) demo on your local machine containing Prometheus, Grafana, cadvisor and node-exporter to monitor your Docker infrastructure and machine.
 
 Prometheus and Grafana is a strong combo which can be used to monitor other things such as Kubernetes.
-If you want to know how to monitor Kubernetes and workloads with Promethus take a look at [Digital Oceans tutorial](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-prometheus-grafana-and-alertmanager-monitoring-stack-on-digitalocean-kubernetes).
+If you want to know how to monitor Kubernetes and workloads with Prometheus take a look at [Digital Oceans tutorial](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-prometheus-grafana-and-alertmanager-monitoring-stack-on-digitalocean-kubernetes).
 
 <img src="./images/dashboard.png" width="1024" heighth="768">
 
@@ -26,7 +26,7 @@ Before we get started setting up the Prometheus demo ensure you install the late
 
 Currently the repo requires 18.06.0+ version of docker and 1.25.0+ of docker-compose as it uses version 3.7 of the compose file format.
 
-You can check your versions by running `docker --version` and "docker-compose --version"
+You can check your versions by running `docker --version` and `docker-compose --version`
 
 # Installation & Configuration
 Clone this project locally to your machine.
@@ -34,9 +34,11 @@ Clone this project locally to your machine.
 If you would like to change which targets should be monitored or make configuration changes edit the `prometheus.yml` file. 
 The targets section is where you define what should be monitored by Prometheus. The names defined in this file are sourced from the service name in the docker-compose file. If you wish to change names of the services you can add the "container_name" parameter in the `docker-compose.yml` file.
 
-This project contains sane defaults meaning that you can just go ahead and start it up by running the foloowing command:
+This project has sensible defaults meaning that you can just go ahead and start it up by running the following command:
 
     $ docker-compose up -d
+
+The above command will collect the latest docker images of the projects used in this repo.
 
 See what containers was started by running
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ If you want to know how to monitor Kubernetes and workloads with Promethus take 
 # Pre-requisites
 Before we get started setting up the Prometheus demo ensure you install the latest version of [docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/) on your machine.
 
+Currently the repo requires 18.06.0+ version of docker and 1.25.0+ of docker-compose as it uses version 3.7 of the compose file format.
+
+You can check your versions by running `docker --version` and "docker-compose --version"
+
 # Installation & Configuration
 Clone this project locally to your machine.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,96 +1,94 @@
-version: '3.1'
+version: '3.7'
 
 volumes:
     prometheus_data: {}
     grafana_data: {}
 
 networks:
-  frontend:
-  backend:
+    frontend:
+    backend:
 
 services:
+    prometheus:
+        container_name: prometheus
+        image: prom/prometheus:latest
+        volumes:
+            - ./prometheus/:/etc/prometheus/
+            - prometheus_data:/prometheus
+        command:
+            - '--config.file=/etc/prometheus/prometheus.yml'
+            - '--storage.tsdb.path=/prometheus'
+            - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+            - '--web.console.templates=/usr/share/prometheus/consoles'
+        ports:
+            - 9090:9090
+        links:
+            - cadvisor:cadvisor
+            - alertmanager:alertmanager
+        depends_on:
+            - cadvisor
+        networks:
+            - backend
+        restart: always
 
-  prometheus:
-    container_name: prometheus
-    image: prom/prometheus
-    volumes:
-      - ./prometheus/:/etc/prometheus/
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
-      - '--web.console.templates=/usr/share/prometheus/consoles'
-    ports:
-      - 9090:9090
-    links:
-      - cadvisor:cadvisor
-      - alertmanager:alertmanager
-    depends_on:
-      - cadvisor
-    networks:
-      - backend
-    restart: always
+    node-exporter:
+        container_name: node-exporter
+        image: prom/node-exporter
+        volumes:
+            - /proc:/host/proc:ro
+            - /sys:/host/sys:ro
+            - /:/rootfs:ro
+        command:
+            - '--path.procfs=/host/proc'
+            - '--path.sysfs=/host/sys'
+            - --collector.filesystem.ignored-mount-points
+            - "^/(sys|proc|dev|host|etc|rootfs/var/lib/docker/containers|rootfs/var/lib/docker/overlay2|rootfs/run/docker/netns|rootfs/var/lib/docker/aufs)($$|/)"
+        ports:
+            - 9100:9100
+        networks:
+            - backend
+        restart: always
 
-  node-exporter:
-    container_name: node-exporter
-    image: prom/node-exporter
-    volumes:
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
-      - /:/rootfs:ro
-    command: 
-      - '--path.procfs=/host/proc' 
-      - '--path.sysfs=/host/sys'
-      - --collector.filesystem.ignored-mount-points
-      - "^/(sys|proc|dev|host|etc|rootfs/var/lib/docker/containers|rootfs/var/lib/docker/overlay2|rootfs/run/docker/netns|rootfs/var/lib/docker/aufs)($$|/)"
-    ports:
-      - 9100:9100
-    networks:
-      - backend
-    restart: always
+    alertmanager:
+        container_name: alertmanager
+        image: prom/alertmanager
+        ports:
+            - 9093:9093
+        volumes:
+            - ./alertmanager/:/etc/alertmanager/
+        networks:
+            - backend
+        restart: always
+        command:
+            - '--config.file=/etc/alertmanager/config.yml'
+            - '--storage.path=/alertmanager'
 
-  alertmanager:
-    container_name: alertmanager
-    image: prom/alertmanager
-    ports:
-      - 9093:9093
-    volumes:
-      - ./alertmanager/:/etc/alertmanager/
-    networks:
-      - backend
-    restart: always
-    command:
-      - '--config.file=/etc/alertmanager/config.yml'
-      - '--storage.path=/alertmanager'
+    cadvisor:
+        container_name: cadvisor
+        image: google/cadvisor
+        volumes:
+            - /:/rootfs:ro
+            - /var/run:/var/run:rw
+            - /sys:/sys:ro
+            - /var/lib/docker/:/var/lib/docker:ro
+        ports:
+            - 8080:8080
+        networks:
+            - backend
+        restart: always
 
-  cadvisor:
-    container_name: cadvisor
-    image: google/cadvisor
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:rw
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-    ports:
-      - 8080:8080
-    networks:
-      - backend
-    restart: always
-
-  grafana:
-    container_name: grafana
-    image: grafana/grafana
-    depends_on:
-      - prometheus
-    ports:
-      - 3000:3000
-    volumes:
-      - grafana_data:/var/lib/grafana
-    env_file:
-      - config.monitoring
-    networks:
-      - backend
-      - frontend
-    restart: always
-
+    grafana:
+        container_name: grafana
+        image: grafana/grafana
+        depends_on:
+            - prometheus
+        ports:
+            - 3000:3000
+        volumes:
+            - grafana_data:/var/lib/grafana
+        env_file:
+            - config.monitoring
+        networks:
+            - backend
+            - frontend
+        restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,6 @@ services:
             - '--web.console.templates=/usr/share/prometheus/consoles'
         ports:
             - 9090:9090
-        links:
-            - cadvisor:cadvisor
-            - alertmanager:alertmanager
         depends_on:
             - cadvisor
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
     node-exporter:
         container_name: node-exporter
-        image: prom/node-exporter
+        image: prom/node-exporter:latest
         volumes:
             - /proc:/host/proc:ro
             - /sys:/host/sys:ro
@@ -51,7 +51,7 @@ services:
 
     alertmanager:
         container_name: alertmanager
-        image: prom/alertmanager
+        image: prom/alertmanager:latest
         ports:
             - 9093:9093
         volumes:
@@ -65,7 +65,7 @@ services:
 
     cadvisor:
         container_name: cadvisor
-        image: google/cadvisor
+        image: google/cadvisor:latest
         volumes:
             - /:/rootfs:ro
             - /var/run:/var/run:rw
@@ -79,7 +79,7 @@ services:
 
     grafana:
         container_name: grafana
-        image: grafana/grafana
+        image: grafana/grafana:latest
         depends_on:
             - prometheus
         ports:

--- a/prometheus/alert.rules
+++ b/prometheus/alert.rules
@@ -5,7 +5,7 @@ groups:
   # Alert for any instance that is unreachable for >2 minutes.
   - alert: service_down
     expr: up == 0
-    for: 2m
+    for: 30s
     labels:
       severity: page
     annotations:
@@ -15,7 +15,7 @@ groups:
  # Alert for any instance that experiences high load for >2 minutes.
   - alert: high_load
     expr: node_load1 > 2.0
-    for: 2m
+    for: 30s
     labels:
       severity: page
     annotations:


### PR DESCRIPTION
Update docker compose version to 3.7
Make required version information available in the README
Make the use of :latest explicit in docker compose
Make highload trigger after 30s instead of 2m
Remove links as it is a deprecated feature